### PR TITLE
Fix Scalding listener example

### DIFF
--- a/example/StatsDProfilerFlowListener.scala
+++ b/example/StatsDProfilerFlowListener.scala
@@ -21,20 +21,24 @@ class StatsDProfilerFlowListener extends FlowListener {
 
     flow.getFlowSteps.toList foreach { fs: FlowStep[_] =>
       val stepNum = fs.getStepNum.toString
-      val conf = fs.getConfig.asInstanceOf[JobConf]
-      val javaAgent = String.format("'-javaagent:/usr/etsy/statsd-jvm-profiler/statsd-jvm-profiler.jar=server=%s,port=%s,prefix=bigdata.profiler.%s.%s.%s.%s,packageWhitelist=com.etsy:com.twitter.scalding:cascading'",
-        statsdHost, statsdPort.toString, userName, jobName, flowId, stepNum)
-      val numMapTasks = conf.get("mapred.map.tasks")
-      val numReduceTasks = conf.get("mapred.reduce.tasks")
+      if (fs.getConfig.isInstanceOf[JobConf]) {
+        val conf = fs.getConfig.asInstanceOf[JobConf]
+        val javaAgent = String.format("'-javaagent:/usr/etsy/statsd-jvm-profiler/statsd-jvm-profiler.jar=server=%s,port=%s,prefix=bigdata.profiler.%s.%s.%s.%s,packageWhitelist=com.etsy:com.twitter.scalding:cascading'",
+          statsdHost, statsdPort.toString, userName, jobName, flowId, stepNum)
+        val numMapTasks = conf.get("mapred.map.tasks")
+        val numReduceTasks = conf.get("mapred.reduce.tasks")
 
-      conf.setBoolean("mapred.task.profile", true)
-      // If you are using YARN you can use the map/reduce specific version of this property
-      // This would allow you to set different parameters if desired
-      conf.set("mapred.task.profile.params", javaAgent)
-      conf.set("mapred.task.profile.maps", getTaskToProfile(numMapTasks,
-        String.format("statsd.profiler.map%s.task", stepNum), conf))
-      conf.set("mapred.task.profile.reduces", getTaskToProfile(numReduceTasks,
-        String.format("statsd.profiler.reduce%s.task", stepNum), conf))
+        conf.setBoolean("mapred.task.profile", true)
+        // If you are using YARN you can use the map/reduce specific version of this property
+        // This would allow you to set different parameters if desired
+        conf.set("mapred.task.profile.params", javaAgent)
+        conf.set("mapred.task.profile.maps", getTaskToProfile(numMapTasks,
+          String.format("statsd.profiler.map%s.task", stepNum), conf))
+        conf.set("mapred.task.profile.reduces", getTaskToProfile(numReduceTasks,
+          String.format("statsd.profiler.reduce%s.task", stepNum), conf))
+      } else {
+        // Profiling is off
+      }
     }
   }
 

--- a/example/StatsDProfilerFlowListener.scala
+++ b/example/StatsDProfilerFlowListener.scala
@@ -5,6 +5,7 @@ import java.util.Random
 import cascading.flow.{Flow, FlowListener, FlowStep}
 import org.apache.hadoop.mapred.JobConf
 
+import scala.util._
 import scala.collection.JavaConversions._
 
 /**
@@ -45,9 +46,10 @@ class StatsDProfilerFlowListener extends FlowListener {
 
   private def getTaskToProfile(numTasks: String, overrideProperty: String, conf: JobConf): String = {
     conf.get(overrideProperty) match {
-      case null => Integer.parseInt(numTasks) match {
-        case 0 => "0"
-        case n: Int => new Random().nextInt(n).toString
+      case null => Try(Integer.parseInt(numTasks)) match {
+        case Success(0) => "0"
+        case Success(n: Int) => new Random().nextInt(n).toString
+        case _ => "0"
       }
       case n: String => n
     }


### PR DESCRIPTION
Two fixes to get the example running for me:
* `numTasks` could be empty (old version of Hadoop probably), so just wrap it in a Try and pattern match accordingly
* Running Scalding unit tests failed `conf` casting and threw a ClassCastException. Since I don't care about profiling unit tests, instance check effectively turns the profiling off. It may be nice to inform the user that this is happening in the else block, but I didn't want to insert a println.