### PR TITLE
Changes to run with long running processes. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,4 @@ Every pull request will be built with [Travis CI](https://travis-ci.org/etsy/sta
 - Joe Meissler [stickperson](https://github.com/stickperson)
 - Ben Darfler [bdarfler](https://github.com/bdarfler)
 - Ihor Bobak [ibobak](https://github.com/ibobak)
+- Jeff Fenchel [jfenc91](https://github.com/jfenc91)

--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ packageWhitelist | Colon-delimited whitelist for packages to include (optional, 
 packageBlacklist | Colon-delimited whitelist for packages to exclude (optional, defaults to exclude nothing)
 profilers        | Colon-delimited list of profiler class names (optional, defaults to CPUProfiler and MemoryProfiler)
 reporter         | Class name of the reporter to use (optional, defaults to StatsDReporter)
-httpPort         | The port on which to bind the embedded HTTP server (optional, defaults to 5005)
+httpPort         | The port on which to bind the embedded HTTP server (optional, defaults to 5005). If this port is already in use, the next free port will be taken.
 
 ### Embedded HTTP Server
 statsd-jvm-profiler embeds an HTTP server to support simple interactions with the profiler while it is in operation.  You can configure the port on which this server runs with the `httpPort` option.
  
-Endpoint            | Usage
----------------     | -----
-/profilers          | List the currently enabled profilers
-/disable/:profiler  | Disable the profiler specified by `:profiler`. The name must match what is returned by `/profilers`.
+Endpoint                    | Usage
+---------------             | -----
+/profilers                  | List the currently enabled profilers
+/isRunning                  | List the running profilers. This should be the same as /profilers.
+/disable/:profiler          | Disable the profiler specified by `:profiler`. The name must match what is returned by `/profilers`.
+/errors                     | List the past 10 errors from the running profilers and reporters.
+/status/profiler/:profiler  | Displays a status message with the number of recorded stats for the requested profiler.
 
 ### Reporters
 statsd-jvm-profiler supports multiple backends.  StatsD is the default, but InfluxDB is also supported.  You can select the backend to use by passing the `reporter` argument to the profiler; `StatsDReporter` and `InfluxDBReporter` are the supported values.

--- a/src/main/java/com/etsy/statsd/profiler/Profiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/Profiler.java
@@ -16,6 +16,7 @@ public abstract class Profiler {
 
     private Reporter<?> reporter;
 
+    private long recordedStats = 0;
     public Profiler(Reporter reporter, Arguments arguments) {
         Preconditions.checkNotNull(reporter);
         this.reporter = reporter;
@@ -71,6 +72,7 @@ public abstract class Profiler {
      * @param value The value of the gauge
      */
     protected void recordGaugeValue(String key, long value) {
+        recordedStats++;
         reporter.recordGaugeValue(key, value);
     }
 
@@ -81,6 +83,9 @@ public abstract class Profiler {
      * @param gauges A map of gauge names to values
      */
     protected void recordGaugeValues(Map<String, Long> gauges) {
+        recordedStats++;
         reporter.recordGaugeValues(gauges);
     }
+
+    public long getRecordedStats() { return recordedStats; }
 }

--- a/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
@@ -12,6 +12,8 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Sets up a simple embedded HTTP server for interacting with the profiler while it runs
@@ -19,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Andrew Johnson
  */
 public class ProfilerServer {
+    private static final Logger log = Logger.getLogger(ProfilerServer.class.getName());
     private static final Vertx vertx = VertxFactory.newVertx();
 
     /**
@@ -36,6 +39,8 @@ public class ProfilerServer {
                 if (event.failed()) {
                     server.close();
                     startServer(runningProfilers, activeProfilers, port + 1, isRunning, errors);
+                } else if (event.succeeded()) {
+                    log.info("Profiler server started on port " + port);
                 }
             }
         });

--- a/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
@@ -1,11 +1,17 @@
 package com.etsy.statsd.profiler.server;
 
+import com.etsy.statsd.profiler.Profiler;
+import com.sun.org.apache.xpath.internal.operations.Bool;
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Handler;
 import org.vertx.java.core.Vertx;
 import org.vertx.java.core.VertxFactory;
 import org.vertx.java.core.http.HttpServer;
 
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Sets up a simple embedded HTTP server for interacting with the profiler while it runs
@@ -21,9 +27,17 @@ public class ProfilerServer {
      * @param activeProfilers The active profilers
      * @param port The port on which to bind the server
      */
-    public static void startServer(final Map<String, ScheduledFuture<?>> activeProfilers, final int port) {
-        HttpServer server = vertx.createHttpServer();
-        server.requestHandler(RequestHandler.getMatcher(activeProfilers));
-        server.listen(port);
+    public static void startServer(final Map<String, ScheduledFuture<?>> runningProfilers, final Map<String, Profiler> activeProfilers, final int port, final AtomicReference<Boolean> isRunning, final LinkedList<String> errors) {
+        final HttpServer server = vertx.createHttpServer();
+        server.requestHandler(RequestHandler.getMatcher(runningProfilers, activeProfilers, isRunning, errors));
+        server.listen(port, new Handler<AsyncResult<HttpServer>>() {
+            @Override
+            public void handle(AsyncResult<HttpServer> event) {
+                if (event.failed()) {
+                    server.close();
+                    startServer(runningProfilers, activeProfilers, port + 1, isRunning, errors);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/etsy/statsd/profiler/worker/ProfilerShutdownHookWorker.java
+++ b/src/main/java/com/etsy/statsd/profiler/worker/ProfilerShutdownHookWorker.java
@@ -3,6 +3,7 @@ package com.etsy.statsd.profiler.worker;
 import com.etsy.statsd.profiler.Profiler;
 
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Worker thread for profiler shutdown hook
@@ -11,9 +12,10 @@ import java.util.Collection;
  */
 public class ProfilerShutdownHookWorker implements Runnable {
     private Collection<Profiler> profilers;
-
-    public ProfilerShutdownHookWorker(Collection<Profiler> profilers) {
+    private AtomicReference<Boolean> isRunning;
+    public ProfilerShutdownHookWorker(Collection<Profiler> profilers, AtomicReference<Boolean> isRunning) {
         this.profilers = profilers;
+        this.isRunning = isRunning;
     }
 
     @Override
@@ -21,5 +23,7 @@ public class ProfilerShutdownHookWorker implements Runnable {
         for (Profiler p : profilers) {
             p.flushData();
         }
+
+        isRunning.set(false);
     }
 }

--- a/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
+++ b/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
@@ -30,7 +30,7 @@ public class ProfilerWorkerThread implements Runnable {
             e.printStackTrace(pw);
             errors.add(String.format("Received an error running profiler: %s, error: %s", profiler.getClass().getName(), sw.toString()));
             if ( errors.size() > 10) {
-                errors.pollLast();
+                errors.pollFirst();
             }
         }
     }

--- a/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
+++ b/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
@@ -2,6 +2,10 @@ package com.etsy.statsd.profiler.worker;
 
 import com.etsy.statsd.profiler.Profiler;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.LinkedList;
+
 /**
  * Worker thread for executing a profiler
  *
@@ -9,13 +13,25 @@ import com.etsy.statsd.profiler.Profiler;
  */
 public class ProfilerWorkerThread implements Runnable {
     private Profiler profiler;
+    private LinkedList<String> errors;
 
-    public ProfilerWorkerThread(Profiler profiler) {
+    public ProfilerWorkerThread(Profiler profiler, LinkedList<String> errors) {
         this.profiler = profiler;
+        this.errors = errors;
     }
 
     @Override
     public void run() {
-        profiler.profile();
+        try {
+            profiler.profile();
+        } catch(Exception e) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            errors.add(String.format("Received an error running profiler: %s, error: %s", profiler.getClass().getName(), sw.toString()));
+            if ( errors.size() > 10) {
+                errors.pollLast();
+            }
+        }
     }
 }

--- a/src/test/java/com/etsy/statsd/profiler/worker/ProfilerShutdownHookWorkerTest.java
+++ b/src/test/java/com/etsy/statsd/profiler/worker/ProfilerShutdownHookWorkerTest.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,8 +21,9 @@ public class ProfilerShutdownHookWorkerTest {
         Profiler mockProfiler1 = new MockProfiler1(output);
         Profiler mockProfiler2 = new MockProfiler2(output);
         Collection<Profiler> profilers = Arrays.asList(mockProfiler1, mockProfiler2);
+        AtomicReference<Boolean> isRunning = new AtomicReference<>(true);
 
-        Thread t = new Thread(new ProfilerShutdownHookWorker(profilers));
+        Thread t = new Thread(new ProfilerShutdownHookWorker(profilers, isRunning));
         t.run();
         t.join();
 
@@ -28,5 +31,6 @@ public class ProfilerShutdownHookWorkerTest {
         expectedOutput.add(MockProfiler1.class.getSimpleName() + "-flushData");
         expectedOutput.add(MockProfiler2.class.getSimpleName() + "-flushData");
         assertEquals(expectedOutput, output);
+        assertEquals(isRunning.get(), false);
     }
 }

--- a/src/test/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThreadTest.java
+++ b/src/test/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThreadTest.java
@@ -5,6 +5,7 @@ import com.etsy.statsd.profiler.profilers.MockProfiler1;
 import org.junit.Test;
 
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -15,7 +16,7 @@ public class ProfilerWorkerThreadTest {
         Set<String> output = new HashSet<>();
         Profiler mockProfiler1 = new MockProfiler1(output);
 
-        Thread t = new Thread(new ProfilerWorkerThread(mockProfiler1));
+        Thread t = new Thread(new ProfilerWorkerThread(mockProfiler1, new LinkedList<String>()));
         t.run();
         t.join();
 


### PR DESCRIPTION
Sorry to lump all these features together on you. I can spend some time to separate them if you are only interested in certain ones. I have been running this on several Elasticsearch 1.7 clusters since I reported the issue. Feel free to review, I will try to get back to this to make improvements/write unit tests.


- Added port incrementing logic when the configured port is already taken
- Added exception handling and a logging endpoint for agents
- Added a endpoint to track the number of times metrics have been sent
  from each agent