### PR TITLE
Loading agent dynamically after VM has started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,4 @@ Every pull request will be built with [Travis CI](https://travis-ci.org/etsy/sta
 - Ben Darfler [bdarfler](https://github.com/bdarfler)
 - Ihor Bobak [ibobak](https://github.com/ibobak)
 - Jeff Fenchel [jfenc91](https://github.com/jfenc91)
+- Alejandro Rivera [AlejandroRivera](https://github.com/AlejandroRivera)

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <manifestEntries>
                                 <Premain-Class>com.etsy.statsd.profiler.Agent</Premain-Class>
+                                <Agent-Class>com.etsy.statsd.profiler.Agent</Agent-Class>
                             </manifestEntries>
                         </transformer>
                     </transformers>

--- a/src/main/java/com/etsy/statsd/profiler/Agent.java
+++ b/src/main/java/com/etsy/statsd/profiler/Agent.java
@@ -29,6 +29,11 @@ public class Agent {
 
     static AtomicReference<Boolean> isRunning = new AtomicReference<>(true);
     static LinkedList<String> errors = new LinkedList<>();
+
+    public static void agentmain(final String args, final Instrumentation instrumentation) {
+        premain(args, instrumentation);
+    }
+
     /**
      * Start the profiler
      *


### PR DESCRIPTION
This PR adds the ability for the JVM Profiler Agent to be loaded dynamically after the VM has already started. 

The code was inspired from a [blog post](http://dhruba.name/2010/02/07/creation-dynamic-loading-and-instrumentation-with-javaagents/) and from reading: Oracle's [Starting Agents After VM Startup](https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html)

