### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/com/etsy/statsd/profiler/Agent.java
+++ b/src/main/java/com/etsy/statsd/profiler/Agent.java
@@ -23,12 +23,12 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Andrew Johnson
  */
 public class Agent {
-    private Agent() { }
-
     public static final int EXECUTOR_DELAY = 0;
 
     static AtomicReference<Boolean> isRunning = new AtomicReference<>(true);
     static LinkedList<String> errors = new LinkedList<>();
+
+    private Agent() { }
 
     public static void agentmain(final String args, final Instrumentation instrumentation) {
         premain(args, instrumentation);

--- a/src/main/java/com/etsy/statsd/profiler/Arguments.java
+++ b/src/main/java/com/etsy/statsd/profiler/Arguments.java
@@ -24,32 +24,6 @@ public class Arguments {
 
     private static final Collection<String> REQUIRED = Arrays.asList(SERVER, PORT);
 
-    /**
-     * Parses arguments into an Arguments object
-     *
-     * @param args A String containing comma-delimited args in k=v form
-     * @return An Arguments object representing the given arguments
-     */
-    public static Arguments parseArgs(final String args) {
-        Map<String, String> parsed = new HashMap<>();
-        for (String argPair : args.split(",")) {
-            String[] tokens = argPair.split("=");
-            if (tokens.length != 2) {
-                throw new IllegalArgumentException("statsd-jvm-profiler takes a comma-delimited list of arguments in k=v form");
-            }
-
-            parsed.put(tokens[0], tokens[1]);
-        }
-
-        for (String requiredArg : REQUIRED) {
-            if (!parsed.containsKey(requiredArg)) {
-                throw new IllegalArgumentException(String.format("%s argument was not supplied", requiredArg));
-            }
-        }
-
-        return new Arguments(parsed);
-    }
-
     public String server;
     public int port;
     public String metricsPrefix;
@@ -75,6 +49,32 @@ public class Arguments {
         remainingArgs = parsedArgs;
     }
 
+    /**
+     * Parses arguments into an Arguments object
+     *
+     * @param args A String containing comma-delimited args in k=v form
+     * @return An Arguments object representing the given arguments
+     */
+    public static Arguments parseArgs(final String args) {
+        Map<String, String> parsed = new HashMap<>();
+        for (String argPair : args.split(",")) {
+            String[] tokens = argPair.split("=");
+            if (tokens.length != 2) {
+                throw new IllegalArgumentException("statsd-jvm-profiler takes a comma-delimited list of arguments in k=v form");
+            }
+
+            parsed.put(tokens[0], tokens[1]);
+        }
+
+        for (String requiredArg : REQUIRED) {
+            if (!parsed.containsKey(requiredArg)) {
+                throw new IllegalArgumentException(String.format("%s argument was not supplied", requiredArg));
+            }
+        }
+
+        return new Arguments(parsed);
+    }
+    
     @SuppressWarnings("unchecked")
     private Class<? extends Reporter<?>> parserReporterArg(String reporterArg) {
         if (reporterArg == null) {

--- a/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
@@ -19,10 +19,10 @@ import java.util.logging.Logger;
  * @author Andrew Johnson
  */
 public class ProfilerServer {
-    private ProfilerServer() { }
-
     private static final Logger LOGGER = Logger.getLogger(ProfilerServer.class.getName());
     private static final Vertx VERTX = VertxFactory.newVertx();
+
+    private ProfilerServer() { }
 
     /**
      * Start an embedded HTTP server

--- a/src/main/java/com/etsy/statsd/profiler/util/TagUtil.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/TagUtil.java
@@ -12,8 +12,6 @@ import java.util.Map;
  * @author Andrew Johnson
  */
 public class TagUtil {
-    private TagUtil() { }
-
     public static final String SKIP_TAG = "SKIP";
     public static final String PREFIX_TAG = "prefix";
 
@@ -21,6 +19,8 @@ public class TagUtil {
     public static final String PID_TAG = "pid";
     public static final String HOSTNAME_TAG = "hostname";
     public static final String JVM_NAME_TAG = "jvmName";
+
+    private TagUtil() { }
 
     public static Map<String, String> getGlobalTags(Map<String, String> tags) {
         // Add the jvm name, pid, hostname as tags to help identify different processes

--- a/src/main/java/com/etsy/statsd/profiler/util/ThreadDumper.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/ThreadDumper.java
@@ -15,9 +15,9 @@ import java.util.Collection;
  * @author Andrew Johnson
  */
 public class ThreadDumper {
-    private ThreadDumper() { }
-
     private static ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+    private ThreadDumper() { }
 
     /**
      * Predicate to filter by thread state

--- a/src/test/java/com/etsy/statsd/profiler/util/MockArguments.java
+++ b/src/test/java/com/etsy/statsd/profiler/util/MockArguments.java
@@ -8,9 +8,9 @@ import java.util.Map;
  * Utility class to create mock arguments for testing
  */
 public class MockArguments {
-    private MockArguments() { }
-
     public static final Arguments BASIC = createArgs("localhost", 8888, "statsd-jvm-profiler", null);
+
+    private MockArguments() { }
 
     /**
      * Create an Arguments instance for testing


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat