### PR TITLE
squid:S2974 - Classes without "public" constructors should be "final"

### DIFF
--- a/src/main/java/com/etsy/statsd/profiler/Agent.java
+++ b/src/main/java/com/etsy/statsd/profiler/Agent.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author Andrew Johnson
  */
-public class Agent {
+public final class Agent {
     public static final int EXECUTOR_DELAY = 0;
 
     static AtomicReference<Boolean> isRunning = new AtomicReference<>(true);

--- a/src/main/java/com/etsy/statsd/profiler/Arguments.java
+++ b/src/main/java/com/etsy/statsd/profiler/Arguments.java
@@ -13,7 +13,7 @@ import java.util.*;
  *
  * @author Andrew Johnson
  */
-public class Arguments {
+public final class Arguments {
     private static final String SERVER = "server";
     private static final String PORT = "port";
     private static final String METRICS_PREFIX = "prefix";

--- a/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
  *
  * @author Andrew Johnson
  */
-public class ProfilerServer {
+public final class ProfilerServer {
     private static final Logger LOGGER = Logger.getLogger(ProfilerServer.class.getName());
     private static final Vertx VERTX = Vertx.factory.vertx();
 

--- a/src/main/java/com/etsy/statsd/profiler/server/RequestHandler.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/RequestHandler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author Andrew Johnson
  */
-public class RequestHandler {
+public final class RequestHandler {
     private RequestHandler() { }
     
     /**

--- a/src/main/java/com/etsy/statsd/profiler/util/MapUtil.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/MapUtil.java
@@ -7,7 +7,7 @@ import java.util.Map;
  *
  * @author Andrew Johnson
  */
-public class MapUtil {
+public final class MapUtil {
     private MapUtil() { }
 
     /**

--- a/src/main/java/com/etsy/statsd/profiler/util/StackTraceFormatter.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/StackTraceFormatter.java
@@ -10,7 +10,7 @@ import java.util.List;
  *
  * @author Andrew Johnson
  */
-public class StackTraceFormatter {
+public final class StackTraceFormatter {
     private StackTraceFormatter() { }
 
     /**

--- a/src/main/java/com/etsy/statsd/profiler/util/TagUtil.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/TagUtil.java
@@ -11,7 +11,7 @@ import java.util.Map;
  *
  * @author Andrew Johnson
  */
-public class TagUtil {
+public final class TagUtil {
     public static final String SKIP_TAG = "SKIP";
     public static final String PREFIX_TAG = "prefix";
 

--- a/src/main/java/com/etsy/statsd/profiler/util/ThreadDumper.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/ThreadDumper.java
@@ -14,7 +14,7 @@ import java.util.Collection;
  *
  * @author Andrew Johnson
  */
-public class ThreadDumper {
+public final class ThreadDumper {
     private static ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 
     private ThreadDumper() { }

--- a/src/main/java/com/etsy/statsd/profiler/util/TimeUtil.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/TimeUtil.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Andrew Johnson
  */
-public class TimeUtil {
+public final class TimeUtil {
     private TimeUtil() { }
 
     /**

--- a/src/test/java/com/etsy/statsd/profiler/util/MockArguments.java
+++ b/src/test/java/com/etsy/statsd/profiler/util/MockArguments.java
@@ -7,7 +7,7 @@ import java.util.Map;
 /**
  * Utility class to create mock arguments for testing
  */
-public class MockArguments {
+public final class MockArguments {
     public static final Arguments BASIC = createArgs("localhost", 8888, "statsd-jvm-profiler", null);
 
     private MockArguments() { }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat