### PR TITLE
Added a new Profiler for CPU/JVM CPU monitoring using (Sun/Oracle) Java7+ JMX Bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ port             | The port number for the server to which the reporter should s
 prefix           | The prefix for metrics (optional, defaults to statsd-jvm-profiler)
 packageWhitelist | Colon-delimited whitelist for packages to include (optional, defaults to include everything)
 packageBlacklist | Colon-delimited whitelist for packages to exclude (optional, defaults to exclude nothing)
-profilers        | Colon-delimited list of profiler class names (optional, defaults to `CPUProfiler` and `MemoryProfiler`)
+profilers        | Colon-delimited list of profiler class names (optional, defaults to `CPUTracingProfiler` and `MemoryProfiler`)
 reporter         | Class name of the reporter to use (optional, defaults to StatsDReporter)
 httpServerEnabled| Determines if the embedded HTTP server should be started. (optional, defaults to `true`)
 httpPort         | The port on which to bind the embedded HTTP server (optional, defaults to 5005). If this port is already in use, the next free port will be taken.
@@ -102,16 +102,16 @@ If you do not want to include a component of `prefix` as a tag, use the special 
 
 ## Profilers
 
-`statsd-jvm-profiler` offers 3 profilers: `MemoryProfiler`, `CPUProfiler` and `JVMCPUProfiler`.
+`statsd-jvm-profiler` offers 3 profilers: `MemoryProfiler`, `CPUTracingProfiler` and `CPULoadProfiler`.
 
 The metrics for all these profilers will prefixed with the value from the `prefix` argument or it's default value: `statsd-jvm-profiler`.
 
 You can enable specific profilers through the `profilers` argument like so:
 1. Memory metrics only: `profilers=MemoryProfiler`
-2. CPU Tracing metrics only: `profilers=CPUProfiler`
-3. JVM/System CPU metrics only: `profilers=JVMCPUProfiler`
+2. CPU Tracing metrics only: `profilers=CPUTracingProfiler`
+3. JVM/System CPU load metrics only: `profilers=CPULoadProfiler`
 
-Default value: `profilers=MemoryProfiler:CPUProfiler`
+Default value: `profilers=MemoryProfiler:CPUTracingProfiler`
 
 ### Garbage Collector and Memory Profiler: `MemoryProfiler`
 This profiler will record:
@@ -125,7 +125,7 @@ the GC metrics will be under `statsd-jvm-profiler.gc`.
 
 Memory and GC metrics are reported once every 10 seconds.
 
-### CPU Tracing Profiler: `CPUProfiler`
+### CPU Tracing Profiler: `CPUTracingProfiler`
 This profiler records the time spent in each function across all Threads.
 
 Assuming you use the default prefix of `statsd-jvm-profiler`, the the CPU time metrics will be under `statsd-jvm-profiler.cpu.trace`.
@@ -139,7 +139,7 @@ of functions that are reported. Any function whose stack trace contains a functi
 
 The `visualization` directory contains some utilities for visualizing the output of this profiler.
 
-### JVM And System CPU Profiler: `JVMCPUProfiler`
+### JVM And System CPU Load Profiler: `CPULoadProfiler`
 
 This profiler will record the JVM's and the overall system's CPU load, if the JVM is capable of providing this information.
 
@@ -151,7 +151,7 @@ The reported metrics will be percentages in the range of [0, 100] with 1 decimal
 CPU load metrics are sampled and reported once every 10 seconds.
 
 Important notes:
-* This Profiler is not enabled by default. To enable use the argument `profilers=JVMCPUProfiler`
+* This Profiler is not enabled by default. To enable use the argument `profilers=CPULoadProfiler`
 * This Profiler relies on Sun/Oracle-specific JVM implementations that offer a JMX bean that might not be available in other JVMs.
   Even if you are using the right JVM, there's no guarantee this JMX bean will remain there in the future.
 * The minimum required JVM version that offers support for this is for Java 7.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.etsy</groupId>
     <artifactId>statsd-jvm-profiler</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>statsd-jvm-profiler</name>

--- a/src/main/java/com/etsy/statsd/profiler/Arguments.java
+++ b/src/main/java/com/etsy/statsd/profiler/Arguments.java
@@ -1,6 +1,6 @@
 package com.etsy.statsd.profiler;
 
-import com.etsy.statsd.profiler.profilers.CPUProfiler;
+import com.etsy.statsd.profiler.profilers.CPUTracingProfiler;
 import com.etsy.statsd.profiler.profilers.MemoryProfiler;
 import com.etsy.statsd.profiler.reporter.Reporter;
 import com.etsy.statsd.profiler.reporter.StatsDReporter;
@@ -97,7 +97,7 @@ public final class Arguments {
     private Set<Class<? extends Profiler>> parseProfilerArg(String profilerArg) {
         Set<Class<? extends Profiler>> parsedProfilers = new HashSet<>();
         if (profilerArg == null) {
-            parsedProfilers.add(CPUProfiler.class);
+            parsedProfilers.add(CPUTracingProfiler.class);
             parsedProfilers.add(MemoryProfiler.class);
         } else {
             for (String p : profilerArg.split(":")) {

--- a/src/main/java/com/etsy/statsd/profiler/Profiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/Profiler.java
@@ -77,12 +77,20 @@ public abstract class Profiler {
     }
 
     /**
+     * @see #recordGaugeValue(String, long)
+     */
+    protected void recordGaugeValue(String key, double value) {
+        recordedStats++;
+        reporter.recordGaugeValue(key, value);
+    }
+
+    /**
      * Record multiple gauge values
      * This is useful for reporters that can send points in batch
      *
      * @param gauges A map of gauge names to values
      */
-    protected void recordGaugeValues(Map<String, Long> gauges) {
+    protected void recordGaugeValues(Map<String, ? extends Number> gauges) {
         recordedStats++;
         reporter.recordGaugeValues(gauges);
     }

--- a/src/main/java/com/etsy/statsd/profiler/Profiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/Profiler.java
@@ -48,7 +48,7 @@ public abstract class Profiler {
     public abstract TimeUnit getTimeUnit();
 
     /**
-     * CPUProfiler can emit some metrics that indicate the upper and lower bound on the length of stack traces
+     * CPUTracingProfiler can emit some metrics that indicate the upper and lower bound on the length of stack traces
      * This is helpful for querying this data for some backends (such as Graphite) that do not have rich query languages
      * Reporters can override this to disable these metrics
      *

--- a/src/main/java/com/etsy/statsd/profiler/profilers/CPULoadProfiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/profilers/CPULoadProfiler.java
@@ -28,7 +28,7 @@ import javax.management.ReflectionException;
  *
  * @author Alejandro Rivera
  */
-public class JVMCPUProfiler extends Profiler {
+public class CPULoadProfiler extends Profiler {
 
   public static final long PERIOD = 10;
   private static final Map<String, String> ATTRIBUTES_MAP = ImmutableMap.of("ProcessCpuLoad", "cpu.jvm",
@@ -36,7 +36,7 @@ public class JVMCPUProfiler extends Profiler {
 
   private AttributeList list;
 
-  public JVMCPUProfiler(Reporter reporter, Arguments arguments) {
+  public CPULoadProfiler(Reporter reporter, Arguments arguments) {
     super(reporter, arguments);
     try {
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();

--- a/src/main/java/com/etsy/statsd/profiler/profilers/CPUTracingProfiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/profilers/CPUTracingProfiler.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Andrew Johnson
  */
-public class CPUProfiler extends Profiler {
+public class CPUTracingProfiler extends Profiler {
     private static final String PACKAGE_WHITELIST_ARG = "packageWhitelist";
     private static final String PACKAGE_BLACKLIST_ARG = "packageBlacklist";
 
@@ -35,7 +35,7 @@ public class CPUProfiler extends Profiler {
     private final long reportingFrequency;
 
 
-    public CPUProfiler(Reporter reporter, Arguments arguments) {
+    public CPUTracingProfiler(Reporter reporter, Arguments arguments) {
         super(reporter, arguments);
         traces = new CPUTraces();
         profileCount = 0;

--- a/src/main/java/com/etsy/statsd/profiler/profilers/JVMCPUProfiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/profilers/JVMCPUProfiler.java
@@ -1,0 +1,114 @@
+package com.etsy.statsd.profiler.profilers;
+
+import com.etsy.statsd.profiler.Arguments;
+import com.etsy.statsd.profiler.Profiler;
+import com.etsy.statsd.profiler.reporter.Reporter;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+/**
+ * This profiler retrieves CPU values for the JVM and System from the "OperatingSystem" JMX Bean.
+ * <p>
+ * This profiler relies on a JMX bean that might not be available in all JVM implementations.
+ * We know for sure it's available in Sun/Oracle's JRE 7+, but there are no guarantees it
+ * will remain there for the foreseeable future.
+ *
+ * @see <a href="http://stackoverflow.com/questions/3044841/cpu-usage-mbean-on-sun-jvm">StackOverflow post</a>
+ *
+ * @author Alejandro Rivera
+ */
+public class JVMCPUProfiler extends Profiler {
+  public static final long PERIOD = 10;
+  public static final double INVALID_VALUE = Double.NaN;
+  private final MBeanServer mbs;
+
+  public JVMCPUProfiler(Reporter reporter, Arguments arguments) {
+    super(reporter, arguments);
+    mbs = ManagementFactory.getPlatformMBeanServer();
+  }
+
+  /**
+   * Profile memory usage and GC statistics
+   */
+  @Override
+  public void profile() {
+    recordStats();
+  }
+
+  @Override
+  public void flushData() {
+    recordStats();
+  }
+
+  @Override
+  public long getPeriod() {
+    return PERIOD;
+  }
+
+  @Override
+  public TimeUnit getTimeUnit() {
+    return TimeUnit.SECONDS;
+  }
+
+  @Override
+  protected void handleArguments(Arguments arguments) { /* No arguments needed */ }
+
+  /**
+   * Records all memory statistics
+   */
+  private void recordStats() {
+    ObjectName os = getOperatingsystemObject();
+    if (os != null) {
+      recordStat(os, "ProcessCpuLoad", "cpu.jvm");
+      recordStat(os, "SystemCpuLoad", "cpu.system");
+    }
+  }
+
+  private void recordStat(ObjectName os, String attribute, String metricKey) {
+    double value = getValue(mbs, os, attribute);
+    if (value != INVALID_VALUE) {
+      recordGaugeValue(metricKey, value);
+    }
+  }
+
+  private ObjectName getOperatingsystemObject() {
+    try {
+      return ObjectName.getInstance("java.lang:type=OperatingSystem");
+    } catch (MalformedObjectNameException e) {
+      return null;
+    }
+  }
+
+  public static double getValue(MBeanServer mbs, ObjectName name, String attribute) {
+
+    AttributeList list;
+    try {
+      list = mbs.getAttributes(name, new String[]{attribute});
+    } catch (InstanceNotFoundException e) {
+      return INVALID_VALUE;
+    } catch (ReflectionException e) {
+      return INVALID_VALUE;
+    }
+
+    if (list.isEmpty()) {
+      return INVALID_VALUE;
+    }
+
+    Attribute att = (Attribute) list.get(0);
+    Double value = (Double) att.getValue();
+
+    if (value == -1.0) {
+      return INVALID_VALUE;
+    }
+
+    return ((int) (value * 1000)) / 10.0d; // 0-100 with 1-decimal precision
+  }
+}

--- a/src/main/java/com/etsy/statsd/profiler/reporter/InfluxDBReporter.java
+++ b/src/main/java/com/etsy/statsd/profiler/reporter/InfluxDBReporter.java
@@ -50,17 +50,25 @@ public class InfluxDBReporter extends Reporter<InfluxDB> {
         recordGaugeValues(gauges);
     }
 
+  /**
+   * @see #recordGaugeValue(String, long)
+   */
+    @Override
+    public void recordGaugeValue(String key, double value) {
+        Map<String, ? extends Number> gauges = ImmutableMap.of(key, value);
+        recordGaugeValues(gauges);
+    }
+
     /**
      * Record multiple gauge values in InfluxDB
      *
      * @param gauges A map of gauge names to values
      */
     @Override
-    public void recordGaugeValues(Map<String, Long> gauges) {
+    public void recordGaugeValues(Map<String, ? extends Number> gauges) {
         long time = System.currentTimeMillis();
-        BatchPoints batchPoints = BatchPoints.database(database)
-                .build();
-        for (Map.Entry<String, Long> gauge: gauges.entrySet()) {
+        BatchPoints batchPoints = BatchPoints.database(database).build();
+        for (Map.Entry<String, ? extends Number> gauge: gauges.entrySet()) {
             batchPoints.point(constructPoint(time, gauge.getKey(), gauge.getValue()));
         }
         client.write(batchPoints);
@@ -106,7 +114,7 @@ public class InfluxDBReporter extends Reporter<InfluxDB> {
         Preconditions.checkNotNull(database);
     }
 
-    private Point constructPoint(long time, String key, long value) {
+    private Point   constructPoint(long time, String key, Number value) {
         Point.Builder builder = Point.measurement(key)
                 .time(time, TimeUnit.MILLISECONDS)
                 .field(VALUE_COLUMN, value);

--- a/src/main/java/com/etsy/statsd/profiler/reporter/InfluxDBReporter.java
+++ b/src/main/java/com/etsy/statsd/profiler/reporter/InfluxDBReporter.java
@@ -75,7 +75,7 @@ public class InfluxDBReporter extends Reporter<InfluxDB> {
     }
 
     /**
-     * InfluxDB has a rich query language and does not need the bounds metrics emitted by CPUProfiler
+     * InfluxDB has a rich query language and does not need the bounds metrics emitted by CPUTracingProfiler
      * As such we can disable emitting these metrics
      *
      * @return false

--- a/src/main/java/com/etsy/statsd/profiler/reporter/Reporter.java
+++ b/src/main/java/com/etsy/statsd/profiler/reporter/Reporter.java
@@ -46,7 +46,7 @@ public abstract class Reporter<T> {
     public abstract void recordGaugeValues(Map<String, ? extends Number> gauges);
 
     /**
-     * CPUProfiler can emit some metrics that indicate the upper and lower bound on the length of stack traces
+     * CPUTracingProfiler can emit some metrics that indicate the upper and lower bound on the length of stack traces
      * This is helpful for querying this data for some backends (such as Graphite) that do not have rich query languages
      * Reporters can override this to disable these metrics
      *

--- a/src/main/java/com/etsy/statsd/profiler/reporter/Reporter.java
+++ b/src/main/java/com/etsy/statsd/profiler/reporter/Reporter.java
@@ -32,13 +32,18 @@ public abstract class Reporter<T> {
      */
     public abstract void recordGaugeValue(String key, long value);
 
+  /**
+   * @see #recordGaugeValue(String, long)
+   */
+    public abstract void recordGaugeValue(String key, double value);
+
     /**
      * Record multiple gauge values
      * This is useful for reporters that can send points in batch
      *
      * @param gauges A map of gauge names to values
      */
-    public abstract void recordGaugeValues(Map<String, Long> gauges);
+    public abstract void recordGaugeValues(Map<String, ? extends Number> gauges);
 
     /**
      * CPUProfiler can emit some metrics that indicate the upper and lower bound on the length of stack traces

--- a/src/main/java/com/etsy/statsd/profiler/reporter/StatsDReporter.java
+++ b/src/main/java/com/etsy/statsd/profiler/reporter/StatsDReporter.java
@@ -27,6 +27,14 @@ public class StatsDReporter extends Reporter<StatsDClient> {
         client.recordGaugeValue(key, value);
     }
 
+  /**
+   * @see #recordGaugeValue(String, long)
+   */
+    @Override
+    public void recordGaugeValue(String key, double value) {
+        client.recordGaugeValue(key, value);
+    }
+
     /**
      * Record multiple gauge values in StatsD
      * This simply loops over calling recordGaugeValue
@@ -34,9 +42,15 @@ public class StatsDReporter extends Reporter<StatsDClient> {
      * @param gauges A map of gauge names to values
      */
     @Override
-    public void recordGaugeValues(Map<String, Long> gauges) {
-        for (Map.Entry<String, Long> gauge : gauges.entrySet()) {
-            recordGaugeValue(gauge.getKey(), gauge.getValue());
+    public void recordGaugeValues(Map<String, ? extends Number> gauges) {
+        for (Map.Entry<String, ? extends Number> gauge : gauges.entrySet()) {
+          if (gauge.getValue() instanceof Long) {
+            client.recordGaugeValue(gauge.getKey(), gauge.getValue().longValue());
+          } else if (gauge.getValue() instanceof Double) {
+            client.recordGaugeValue(gauge.getKey(), gauge.getValue().doubleValue());
+          } else {
+            throw new IllegalArgumentException("Unexpected Number type: " + gauge.getValue().getClass().getSimpleName());
+          }
         }
     }
 

--- a/src/main/java/com/etsy/statsd/profiler/util/CPUTraces.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/CPUTraces.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * @author Andrew Johnson
  */
 public class CPUTraces {
-    private Map<String, Long> traces;
+    private Map<String, Number> traces;
     private int max = Integer.MIN_VALUE;
     private int min = Integer.MAX_VALUE;
 
@@ -33,8 +33,8 @@ public class CPUTraces {
      * It only returns traces that have been updated since the last flush
      *
      */
-    public Map<String, Long> getDataToFlush() {
-        Map<String, Long> result = traces;
+    public Map<String, Number> getDataToFlush() {
+        Map<String, Number> result = traces;
         traces = new HashMap<>();
         return result;
     }

--- a/src/main/java/com/etsy/statsd/profiler/util/MapUtil.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/MapUtil.java
@@ -17,12 +17,24 @@ public final class MapUtil {
      * @param key The key for the map
      * @param inc The new value or increment for the given key
      */
-    public static void setOrIncrementMap(Map<String, Long> map, String key, long inc) {
-        Long val = map.get(key);
+    public static void setOrIncrementMap(Map<String, Number> map, String key, Number inc) {
+        Number val = map.get(key);
         if (val == null) {
-            map.put(key, inc);
+            if (inc instanceof Double) {
+                map.put(key, inc.doubleValue());
+            } else if (inc instanceof Long || inc instanceof Integer) {
+                map.put(key, inc.longValue());
+            } else {
+                throw new IllegalArgumentException("Unexpected Number type: " + inc.getClass().getSimpleName());
+            }
         } else {
-            map.put(key, val + inc);
+            if (val instanceof Double) {
+                map.put(key, val.doubleValue() + inc.doubleValue());
+            } else if (val instanceof Long || val instanceof Integer) {
+                map.put(key, val.longValue() + inc.longValue());
+            } else {
+                throw new IllegalArgumentException("Unexpected Number type: " + val.getClass().getSimpleName());
+            }
         }
     }
 }

--- a/src/test/java/com/etsy/statsd/profiler/ArgumentsTest.java
+++ b/src/test/java/com/etsy/statsd/profiler/ArgumentsTest.java
@@ -1,6 +1,6 @@
 package com.etsy.statsd.profiler;
 
-import com.etsy.statsd.profiler.profilers.CPUProfiler;
+import com.etsy.statsd.profiler.profilers.CPUTracingProfiler;
 import com.etsy.statsd.profiler.profilers.MemoryProfiler;
 import com.etsy.statsd.profiler.reporter.InfluxDBReporter;
 import com.etsy.statsd.profiler.reporter.StatsDReporter;
@@ -69,7 +69,7 @@ public class ArgumentsTest {
         Arguments arguments = Arguments.parseArgs(args);
 
         Set<Class<? extends Profiler>> expected = new HashSet<>();
-        expected.add(CPUProfiler.class);
+        expected.add(CPUTracingProfiler.class);
         expected.add(MemoryProfiler.class);
 
         assertEquals(expected, arguments.profilers);
@@ -77,11 +77,11 @@ public class ArgumentsTest {
 
     @Test
     public void testProfilerWithPackage() {
-        String args = "server=localhost,port=8125,profilers=com.etsy.statsd.profiler.profilers.CPUProfiler";
+        String args = "server=localhost,port=8125,profilers=com.etsy.statsd.profiler.profilers.CPUTracingProfiler";
         Arguments arguments = Arguments.parseArgs(args);
 
         Set<Class<? extends Profiler>> expected = new HashSet<>();
-        expected.add(CPUProfiler.class);
+        expected.add(CPUTracingProfiler.class);
 
         assertEquals(expected, arguments.profilers);
     }
@@ -99,11 +99,11 @@ public class ArgumentsTest {
 
     @Test
     public void testMultipleProfilers() {
-        String args = "server=localhost,port=8125,profilers=CPUProfiler:MemoryProfiler";
+        String args = "server=localhost,port=8125,profilers=CPUTracingProfiler:MemoryProfiler";
         Arguments arguments = Arguments.parseArgs(args);
 
         Set<Class<? extends Profiler>> expected = new HashSet<>();
-        expected.add(CPUProfiler.class);
+        expected.add(CPUTracingProfiler.class);
         expected.add(MemoryProfiler.class);
 
         assertEquals(expected, arguments.profilers);

--- a/src/test/java/com/etsy/statsd/profiler/reporter/MockReporter.java
+++ b/src/test/java/com/etsy/statsd/profiler/reporter/MockReporter.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * @author Andrew Johnson
  */
 public class MockReporter extends Reporter<String> {
-    private Map<String, Long> output;
+    private Map<String, Number> output;
 
     public MockReporter() {
         super(MockArguments.BASIC);
@@ -26,10 +26,21 @@ public class MockReporter extends Reporter<String> {
     }
 
     @Override
-    public void recordGaugeValues(Map<String, Long> gauges) {
-        for (Map.Entry<String, Long> gauge : gauges.entrySet()) {
-            recordGaugeValue(gauge.getKey(), gauge.getValue());
+    public void recordGaugeValues(Map<String, ? extends Number> gauges) {
+        for (Map.Entry<String, ? extends Number> gauge : gauges.entrySet()) {
+            if (gauge.getValue() instanceof Long) {
+                recordGaugeValue(gauge.getKey(), gauge.getValue().longValue());
+            } else if (gauge.getValue() instanceof Double) {
+                recordGaugeValue(gauge.getKey(), gauge.getValue().doubleValue());
+            } else {
+                throw new IllegalArgumentException("Unexpected Number type: " + gauge.getValue().getClass().getSimpleName());
+            }
         }
+    }
+
+    @Override
+    public void recordGaugeValue(String key, double value) {
+        MapUtil.setOrIncrementMap(output, key, value);
     }
 
     @Override
@@ -40,7 +51,7 @@ public class MockReporter extends Reporter<String> {
     @Override
     protected void handleArguments(Arguments arguments) { }
 
-    public Map<String, Long> getOutput() {
+    public Map<String, Number> getOutput() {
         return output;
     }
 }

--- a/src/test/java/com/etsy/statsd/profiler/util/MapUtilTest.java
+++ b/src/test/java/com/etsy/statsd/profiler/util/MapUtilTest.java
@@ -11,7 +11,7 @@ public class MapUtilTest {
 
     @Test
     public void testSetOrIncrementMap() {
-        Map<String, Long> map = new HashMap<>();
+        Map<String, Number> map = new HashMap<>();
         MapUtil.setOrIncrementMap(map, "key", 1);
         assertEquals(new Long(1L), map.get("key"));
 

--- a/src/test/java/com/etsy/statsd/profiler/util/StackTraceFilterTest.java
+++ b/src/test/java/com/etsy/statsd/profiler/util/StackTraceFilterTest.java
@@ -1,6 +1,6 @@
 package com.etsy.statsd.profiler.util;
 
-import com.etsy.statsd.profiler.profilers.CPUProfiler;
+import com.etsy.statsd.profiler.profilers.CPUTracingProfiler;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -22,7 +22,7 @@ public class StackTraceFilterTest {
     @BeforeClass
     public static void setup() {
         includePackages = Arrays.asList("com.etsy", "com.twitter.scalding");
-        filter = new StackTraceFilter(includePackages, CPUProfiler.EXCLUDE_PACKAGES);
+        filter = new StackTraceFilter(includePackages, CPUTracingProfiler.EXCLUDE_PACKAGES);
         excludedTraces = Arrays.asList("com-etsy-statsd-profiler-profiler-util-StackTraceFormatter-formatStackTraceElement", "com-timgroup-statsd-StatsDClient-send", "com-etsy-statsd-profiler-profiler-util-StackTraceFormatter-formatStackTraceElement.com-etsy-Foo-fooTest");
         includedTraces = Collections.singletonList("com-etsy-foo-fooTest");
         otherTraces = Collections.singletonList("com-google-guava-Foo-helloWorld");


### PR DESCRIPTION
While the current CPU profiler focuses on breakdowns per thread, this new profiler obtains CPU load (in percentage) for the entire JVM and the system.

Here's the description taken from the modified README file:

### JVM And System CPU Profiler: `JVMCPUProfiler`

This profiler will record the JVM's and the overall system's CPU load, if the JVM is capable of providing this information.

Assuming you use the default prefix of `statsd-jvm-profiler`, the JVM CPU load metrics will be under `statsd-jvm-profiler.cpu.jvm`,
and the System CPU load wil be under `statsd-jvm-profiler.cpu.system`.

The reported metrics will be percentages in the range of [0, 100] with 1 decimal precision.

CPU load metrics are sampled and reported once every 10 seconds.

Important notes:
* This Profiler is not enabled by default. To enable use the argument `profilers=JVMCPUProfiler`
* This Profiler relies on Sun/Oracle-specific JVM implementations that offer a JMX bean that might not be available in other JVMs.
  Even if you are using the right JVM, there's no guarantee this JMX bean will remain there in the future.
* The minimum required JVM version that offers support for this is for Java 7.
* See [com.sun.management.OperatingSystemMXBean](https://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad())
  for more information.
* If the JVM doesn't support the required operations, the metrics above won't be reported at all.
