### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/src/main/java/com/etsy/statsd/profiler/Arguments.java
+++ b/src/main/java/com/etsy/statsd/profiler/Arguments.java
@@ -76,7 +76,7 @@ public final class Arguments {
     }
     
     @SuppressWarnings("unchecked")
-    private Class<? extends Reporter<?>> parserReporterArg(String reporterArg) {
+    private static Class<? extends Reporter<?>> parserReporterArg(String reporterArg) {
         if (reporterArg == null) {
             return StatsDReporter.class;
         } else {
@@ -94,7 +94,7 @@ public final class Arguments {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Class<? extends Profiler>> parseProfilerArg(String profilerArg) {
+    private static Set<Class<? extends Profiler>> parseProfilerArg(String profilerArg) {
         Set<Class<? extends Profiler>> parsedProfilers = new HashSet<>();
         if (profilerArg == null) {
             parsedProfilers.add(CPUTracingProfiler.class);

--- a/src/main/java/com/etsy/statsd/profiler/profilers/CPUTracingProfiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/profilers/CPUTracingProfiler.java
@@ -103,7 +103,7 @@ public class CPUTracingProfiler extends Profiler {
      * @param packages A string containing a colon-delimited list of packages
      * @return A List of packages
      */
-    private List<String> parsePackageList(String packages) {
+    private static List<String> parsePackageList(String packages) {
         if (packages == null) {
             return new ArrayList<>();
         } else {
@@ -123,7 +123,7 @@ public class CPUTracingProfiler extends Profiler {
      *
      * @return A Collection<ThreadInfo> representing current thread state
      */
-    private Collection<ThreadInfo> getAllRunnableThreads() {
+    private static Collection<ThreadInfo> getAllRunnableThreads() {
         return ThreadDumper.filterAllThreadsInState(false, false, Thread.State.RUNNABLE, new Predicate<ThreadInfo>() {
             @Override
             public boolean apply(ThreadInfo input) {

--- a/src/main/java/com/etsy/statsd/profiler/profilers/MemoryProfiler.java
+++ b/src/main/java/com/etsy/statsd/profiler/profilers/MemoryProfiler.java
@@ -119,7 +119,7 @@ public class MemoryProfiler extends Profiler {
      * @param prefix The prefix to use for this object
      * @param memory The MemoryUsage object containing the memory usage info
      */
-    private void recordMemoryUsage(String prefix, MemoryUsage memory, Map<String, Long> metrics) {
+    private static void recordMemoryUsage(String prefix, MemoryUsage memory, Map<String, Long> metrics) {
         metrics.put(prefix + ".init", memory.getInit());
         metrics.put(prefix + ".used", memory.getUsed());
         metrics.put(prefix + ".committed", memory.getCommitted());
@@ -132,7 +132,7 @@ public class MemoryProfiler extends Profiler {
      * @param memoryType a MemoryType
      * @return a valid metric name
      */
-    private String poolTypeToMetricName(MemoryType memoryType) {
+    private static String poolTypeToMetricName(MemoryType memoryType) {
         switch (memoryType) {
             case HEAP:
                 return "heap";
@@ -149,7 +149,7 @@ public class MemoryProfiler extends Profiler {
      * @param poolName a pool name
      * @return a valid metric name
      */
-    private String poolNameToMetricName(String poolName) {
+    private static String poolNameToMetricName(String poolName) {
         return poolName.toLowerCase().replaceAll("\\s+", "-");
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat