### PR TITLE
Multiple quality improvements

### DIFF
--- a/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/ProfilerServer.java
@@ -7,7 +7,7 @@ import org.vertx.java.core.Vertx;
 import org.vertx.java.core.VertxFactory;
 import org.vertx.java.core.http.HttpServer;
 
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,7 +30,7 @@ public final class ProfilerServer {
      * @param activeProfilers The active profilers
      * @param port The port on which to bind the server
      */
-    public static void startServer(final Map<String, ScheduledFuture<?>> runningProfilers, final Map<String, Profiler> activeProfilers, final int port, final AtomicReference<Boolean> isRunning, final LinkedList<String> errors) {
+    public static void startServer(final Map<String, ScheduledFuture<?>> runningProfilers, final Map<String, Profiler> activeProfilers, final int port, final AtomicReference<Boolean> isRunning, final List<String> errors) {
         final HttpServer server = VERTX.createHttpServer();
         server.requestHandler(RequestHandler.getMatcher(runningProfilers, activeProfilers, isRunning, errors));
         server.listen(port, new Handler<AsyncResult<HttpServer>>() {

--- a/src/main/java/com/etsy/statsd/profiler/server/RequestHandler.java
+++ b/src/main/java/com/etsy/statsd/profiler/server/RequestHandler.java
@@ -10,7 +10,7 @@ import org.vertx.java.core.http.HttpServerRequest;
 import org.vertx.java.core.http.RouteMatcher;
 
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,7 +29,7 @@ public final class RequestHandler {
      * @param activeProfilers The active profilers
      * @return A RouteMatcher that matches all supported routes
      */
-    public static RouteMatcher getMatcher(final Map<String, ScheduledFuture<?>> runningProfilers,  Map<String, Profiler> activeProfilers, AtomicReference<Boolean> isRunning, LinkedList<String> errors) {
+    public static RouteMatcher getMatcher(final Map<String, ScheduledFuture<?>> runningProfilers,  Map<String, Profiler> activeProfilers, AtomicReference<Boolean> isRunning, List<String> errors) {
         RouteMatcher matcher = new RouteMatcher();
         matcher.get("/profilers", RequestHandler.handleGetProfilers(runningProfilers));
         matcher.get("/disable/:profiler", RequestHandler.handleDisableProfiler(runningProfilers));
@@ -72,7 +72,7 @@ public final class RequestHandler {
      *
      * @return The last 10 error stacktraces
      */
-    public static Handler<HttpServerRequest> handleErrorMessages(final LinkedList<String> errors) {
+    public static Handler<HttpServerRequest> handleErrorMessages(final List<String> errors) {
         return new Handler<HttpServerRequest>() {
             @Override
             public void handle(HttpServerRequest httpServerRequest) {

--- a/src/main/java/com/etsy/statsd/profiler/util/StackTraceFilter.java
+++ b/src/main/java/com/etsy/statsd/profiler/util/StackTraceFilter.java
@@ -67,7 +67,7 @@ public class StackTraceFilter {
      * @param formattedStackTrace The stack trace to check against the pattern
      * @return True if the stack trace matches the pattern, false otherwise
      */
-    private boolean matches(Pattern pattern, String formattedStackTrace) {
+    private static boolean matches(Pattern pattern, String formattedStackTrace) {
         Matcher matcher = pattern.matcher(formattedStackTrace);
 
         return matcher.matches();

--- a/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
+++ b/src/main/java/com/etsy/statsd/profiler/worker/ProfilerWorkerThread.java
@@ -5,6 +5,7 @@ import com.etsy.statsd.profiler.Profiler;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Worker thread for executing a profiler
@@ -13,9 +14,9 @@ import java.util.LinkedList;
  */
 public class ProfilerWorkerThread implements Runnable {
     private final Profiler profiler;
-    private final LinkedList<String> errors;
+    private final List<String> errors;
 
-    public ProfilerWorkerThread(Profiler profiler, LinkedList<String> errors) {
+    public ProfilerWorkerThread(Profiler profiler, List<String> errors) {
         this.profiler = profiler;
         this.errors = errors;
     }
@@ -30,7 +31,7 @@ public class ProfilerWorkerThread implements Runnable {
             e.printStackTrace(pw);
             errors.add(String.format("Received an error running profiler: %s, error: %s", profiler.getClass().getName(), sw.toString()));
             if (errors.size() > 10) {
-                errors.pollFirst();
+                ((LinkedList) errors).pollFirst();
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"
squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat